### PR TITLE
fixed pathname error on Steam Batch File Generation

### DIFF
--- a/SCMD Workshop Downloader 2.py
+++ b/SCMD Workshop Downloader 2.py
@@ -1973,7 +1973,7 @@ class scmdwd(QtWidgets.QMainWindow):
         self.itemcondition='https://steamcommunity.com/sharedfiles/filedetails/?id='
         self.collectioncondition='https://steamcommunity.com/workshop/browse/?section=collections&appid='
     def PreScript(self):
-        self.script=f'{self.realpath}'
+        self.script=f'\"{self.realpath}\"'
         if self.data["cdf"]==True:
             self.script+=f' +force_install_dir {os.path.realpath(self.data["dfolder"])}'
         self.script+=' +login '


### PR DESCRIPTION
Had an error when generating a bat file and the user's steamcmd.exe pathname had a space
ex. C:\Downloads\Dollie Son\steamcmd.exe
would count as separate commands
"C:\Downloads\Dollie" and "Son\steamcmd.exe"

just covered them with ""